### PR TITLE
Add Twitch Predictions Endpoints and Fix Build Errors

### DIFF
--- a/StreamActions.Twitch/Api/Chat/ChatSettings.cs
+++ b/StreamActions.Twitch/Api/Chat/ChatSettings.cs
@@ -19,6 +19,7 @@
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using StreamActions.Common;
 using StreamActions.Common.Exceptions;
 using StreamActions.Common.Extensions;
 using StreamActions.Common.Logger;
@@ -37,7 +38,7 @@ public sealed record ChatSettings
     /// The ID of the broadcaster.
     /// </summary>
     [JsonPropertyName("broadcaster_id")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWriting)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? BroadcasterId { get; init; }
 
     /// <summary>
@@ -62,7 +63,7 @@ public sealed record ChatSettings
     /// The moderator's ID.
     /// </summary>
     [JsonPropertyName("moderator_id")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWriting)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ModeratorId { get; init; }
 
     /// <summary>

--- a/StreamActions.Twitch/Api/Common/TwitchSession.cs
+++ b/StreamActions.Twitch/Api/Common/TwitchSession.cs
@@ -126,18 +126,6 @@ public sealed record TwitchSession : IDisposable
     }
 
     /// <summary>
-    /// Checks if either an app or user token is present and contains any of the specified scopes.
-    /// </summary>
-    /// <param name="scopes">The scopes to check for.</param>
-    /// <exception cref="InvalidOperationException"><see cref="Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
-    /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.App"/> or <see cref="TwitchToken.TokenType.User"/>.</exception>
-    /// <exception cref="TwitchScopeMissingException"><see cref="TwitchToken.Type"/> is <see cref="TwitchToken.TokenType.User"/> and <see cref="TwitchToken.Scopes"/> does not contain any of the scopes defined in <paramref name="scopes"/>.</exception>
-    /// <remarks>
-    /// If <see cref="TwitchToken.Scopes"/> is <see langword="null"/>, then checking of <paramref name="scopes"/> is skipped.
-    /// </remarks>
-    public void RequireToken(params Scope?[]? scopes) => this.RequireUserOrAppToken(scopes);
-
-    /// <summary>
     /// Checks if a user token is present and contains any of the specified scopes.
     /// </summary>
     /// <param name="scopes">The scopes to check for.</param>

--- a/StreamActions.Twitch/Api/Common/TwitchSession.cs
+++ b/StreamActions.Twitch/Api/Common/TwitchSession.cs
@@ -88,12 +88,12 @@ public sealed record TwitchSession : IDisposable
     }
 
     /// <summary>
-    /// Checks if either an app or user token is present. If it is a user token, also checks if the specified scopes are present.
+    /// Checks if either an app or user token is present. If it is a user token, also checks if any of the specified scopes are present.
     /// </summary>
     /// <param name="scopes">The scopes to check for.</param>
     /// <exception cref="InvalidOperationException"><see cref="Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
     /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.App"/> or <see cref="TwitchToken.TokenType.User"/>.</exception>
-    /// <exception cref="TwitchScopeMissingException"><see cref="TwitchToken.Type"/> is <see cref="TwitchToken.TokenType.User"/> and <see cref="TwitchToken.Scopes"/> does not contain all of the scopes defined in <paramref name="scopes"/>.</exception>
+    /// <exception cref="TwitchScopeMissingException"><see cref="TwitchToken.Type"/> is <see cref="TwitchToken.TokenType.User"/> and <see cref="TwitchToken.Scopes"/> does not contain any of the scopes defined in <paramref name="scopes"/>.</exception>
     /// <remarks>
     /// If <see cref="TwitchToken.Scopes"/> is <see langword="null"/>, then checking of <paramref name="scopes"/> is skipped.
     /// </remarks>
@@ -116,9 +116,9 @@ public sealed record TwitchSession : IDisposable
 
         if (this.Token.Type is TwitchToken.TokenType.User)
         {
-            (_, Scope?[] Missing) = this.Token.CheckScopes(scopes);
+            (Scope?[] Found, Scope?[] Missing) = this.Token.CheckScopes(scopes);
 
-            if (Missing.Length > 0)
+            if (scopes is not null && scopes.Length > 0 && Found.Length == 0)
             {
                 throw new TwitchScopeMissingException(Missing).Log(TwitchApi.GetLogger());
             }
@@ -126,12 +126,24 @@ public sealed record TwitchSession : IDisposable
     }
 
     /// <summary>
-    /// Checks if a user token is present and contains the specified scopes.
+    /// Checks if either an app or user token is present and contains any of the specified scopes.
+    /// </summary>
+    /// <param name="scopes">The scopes to check for.</param>
+    /// <exception cref="InvalidOperationException"><see cref="Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.App"/> or <see cref="TwitchToken.TokenType.User"/>.</exception>
+    /// <exception cref="TwitchScopeMissingException"><see cref="TwitchToken.Type"/> is <see cref="TwitchToken.TokenType.User"/> and <see cref="TwitchToken.Scopes"/> does not contain any of the scopes defined in <paramref name="scopes"/>.</exception>
+    /// <remarks>
+    /// If <see cref="TwitchToken.Scopes"/> is <see langword="null"/>, then checking of <paramref name="scopes"/> is skipped.
+    /// </remarks>
+    public void RequireToken(params Scope?[]? scopes) => this.RequireUserOrAppToken(scopes);
+
+    /// <summary>
+    /// Checks if a user token is present and contains any of the specified scopes.
     /// </summary>
     /// <param name="scopes">The scopes to check for.</param>
     /// <exception cref="InvalidOperationException"><see cref="Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
     /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.User"/>.</exception>
-    /// <exception cref="TwitchScopeMissingException"><see cref="TwitchToken.Scopes"/> does not contain all of the scopes defined in <paramref name="scopes"/>.</exception>
+    /// <exception cref="TwitchScopeMissingException"><see cref="TwitchToken.Scopes"/> does not contain any of the scopes defined in <paramref name="scopes"/>.</exception>
     /// <remarks>
     /// If <see cref="TwitchToken.Scopes"/> is <see langword="null"/>, then checking of <paramref name="scopes"/> is skipped.
     /// </remarks>
@@ -152,9 +164,9 @@ public sealed record TwitchSession : IDisposable
             throw new TokenTypeException(Enum.GetName(TwitchToken.TokenType.User), Enum.GetName(this.Token.Type ?? TwitchToken.TokenType.Unknown)).Log(TwitchApi.GetLogger());
         }
 
-        (_, Scope?[] Missing) = this.Token.CheckScopes(scopes);
+        (Scope?[] Found, Scope?[] Missing) = this.Token.CheckScopes(scopes);
 
-        if (Missing.Length > 0)
+        if (scopes is not null && scopes.Length > 0 && Found.Length == 0)
         {
             throw new TwitchScopeMissingException(Missing).Log(TwitchApi.GetLogger());
         }

--- a/StreamActions.Twitch/Api/Predictions/Prediction.cs
+++ b/StreamActions.Twitch/Api/Predictions/Prediction.cs
@@ -1,0 +1,422 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using StreamActions.Common;
+using StreamActions.Common.Extensions;
+using StreamActions.Common.Json.Serialization;
+using StreamActions.Common.Logger;
+using StreamActions.Twitch.Api.Common;
+using StreamActions.Twitch.Exceptions;
+using StreamActions.Twitch.OAuth;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Globalization;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Predictions;
+
+/// <summary>
+/// Represents a prediction that viewers can participate in.
+/// </summary>
+public sealed record Prediction
+{
+    /// <summary>
+    /// An ID that identifies the prediction.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public Guid? Id { get; init; }
+
+    /// <summary>
+    /// An ID that identifies the broadcaster that created the prediction.
+    /// </summary>
+    [JsonPropertyName("broadcaster_id")]
+    public string? BroadcasterId { get; init; }
+
+    /// <summary>
+    /// The broadcaster's display name.
+    /// </summary>
+    [JsonPropertyName("broadcaster_name")]
+    public string? BroadcasterName { get; init; }
+
+    /// <summary>
+    /// The broadcaster's login name.
+    /// </summary>
+    [JsonPropertyName("broadcaster_login")]
+    public string? BroadcasterLogin { get; init; }
+
+    /// <summary>
+    /// The question that the broadcaster is asking.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// The ID of the winning outcome.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This field is <see langword="null"/> until the prediction is <see cref="PredictionStatus.Resolved"/>.
+    /// </para>
+    /// </remarks>
+    [JsonPropertyName("winning_outcome_id")]
+    public Guid? WinningOutcomeId { get; init; }
+
+    /// <summary>
+    /// A list of possible outcomes for the prediction.
+    /// </summary>
+    [JsonPropertyName("outcomes")]
+    public IReadOnlyList<PredictionOutcome>? Outcomes { get; init; }
+
+    /// <summary>
+    /// The length of time (in seconds) that the prediction will run for.
+    /// </summary>
+    [JsonPropertyName("prediction_window")]
+    public int? PredictionWindowSeconds { get; init; }
+
+    /// <summary>
+    /// The length of time that the prediction will run for.
+    /// </summary>
+    [JsonIgnore]
+    public TimeSpan? PredictionWindow => this.PredictionWindowSeconds.HasValue ? TimeSpan.FromSeconds(this.PredictionWindowSeconds.Value) : null;
+
+    /// <summary>
+    /// The prediction's status.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public PredictionStatus? Status { get; init; }
+
+    /// <summary>
+    /// The UTC date and time of when the prediction began.
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public DateTime? CreatedAt { get; init; }
+
+    /// <summary>
+    /// The UTC date and time of when the prediction ended.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This field is <see langword="null"/> if the prediction is <see cref="PredictionStatus.Active"/>.
+    /// </para>
+    /// </remarks>
+    [JsonPropertyName("ended_at")]
+    public DateTime? EndedAt { get; init; }
+
+    /// <summary>
+    /// The UTC date and time of when the prediction was locked.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This field is <see langword="null"/> if the prediction is <see cref="PredictionStatus.Active"/>.
+    /// </para>
+    /// </remarks>
+    [JsonPropertyName("locked_at")]
+    public DateTime? LockedAt { get; init; }
+
+    /// <summary>
+    /// The prediction's status.
+    /// </summary>
+    [JsonConverter(typeof(JsonUpperCaseEnumConverter<PredictionStatus>))]
+    public enum PredictionStatus
+    {
+        /// <summary>
+        /// Something went wrong while determining the state.
+        /// </summary>
+        Invalid,
+        /// <summary>
+        /// The prediction is running.
+        /// </summary>
+        Active,
+        /// <summary>
+        /// The prediction was canceled and Channel Points were refunded to predictors.
+        /// </summary>
+        Canceled,
+        /// <summary>
+        /// The prediction is locked and viewers can no longer participate.
+        /// </summary>
+        Locked,
+        /// <summary>
+        /// The prediction has been resolved and Channel Points have been awarded to the winners.
+        /// </summary>
+        Resolved
+    }
+
+    /// <summary>
+    /// Gets a list of predictions that the broadcaster created.
+    /// </summary>
+    /// <param name="session">The <see cref="TwitchSession"/> to authorize the request.</param>
+    /// <param name="broadcasterId">The ID of the broadcaster that created the predictions. This ID must match the user ID in the user access token.</param>
+    /// <param name="id">A list of IDs that identify the predictions to return. Specify this parameter only if you want to filter the list that the request returns. The endpoint ignores duplicate IDs and those not owned by this broadcaster. Maximum: 25</param>
+    /// <param name="first">The maximum number of items to return per page in the response. Maximum: 25. Default: 20.</param>
+    /// <param name="after">The cursor used to get the next page of results.</param>
+    /// <returns>A <see cref="ResponseData{TDataType}"/> with elements of type <see cref="Prediction"/> containing the response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>; <paramref name="broadcasterId"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="id"/> is not <see langword="null"/> and has more than 25 elements.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="TwitchSession.Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TwitchScopeMissingException"><paramref name="session"/> does not have the scope <see cref="Scope.ChannelReadPredictions"/> or <see cref="Scope.ChannelManagePredictions"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Predictions are available for 90 days after they're created.
+    /// </para>
+    /// <para>
+    /// Response Codes:
+    /// <list type="table">
+    /// <item>
+    /// <term>200 OK</term>
+    /// <description>Successfully retrieved the broadcaster's predictions.</description>
+    /// </item>
+    /// <item>
+    /// <term>400 Bad Request</term>
+    /// <description>The described parameter was missing or invalid.</description>
+    /// </item>
+    /// <item>
+    /// <term>401 Unauthorized</term>
+    /// <description>The OAuth token was invalid for this request due to the specified reason.</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public static async Task<ResponseData<Prediction>?> GetPredictions(TwitchSession session, string broadcasterId, IEnumerable<Guid>? id = null, int first = 20, string? after = null)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
+        }
+
+        if (string.IsNullOrWhiteSpace(broadcasterId))
+        {
+            throw new ArgumentNullException(nameof(broadcasterId)).Log(TwitchApi.GetLogger());
+        }
+
+        if (id is not null && id.Count() > 25)
+        {
+            throw new ArgumentOutOfRangeException(nameof(id), id.Count(), "must have a count <= 25").Log(TwitchApi.GetLogger());
+        }
+
+        session.RequireToken(Scope.ChannelReadPredictions, Scope.ChannelManagePredictions);
+
+        first = Math.Clamp(first, 1, 25);
+
+        NameValueCollection queryParams = new()
+        {
+            { "broadcaster_id", broadcasterId },
+            { "first", first.ToString(CultureInfo.InvariantCulture) }
+        };
+
+        if (id is not null && id.Any())
+        {
+            List<string> ids = [];
+            foreach (Guid predictionId in id)
+            {
+                ids.Add(predictionId.ToString());
+            }
+
+            if (ids.Count != 0)
+            {
+                queryParams.Add("id", ids);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(after))
+        {
+            queryParams.Add("after", after);
+        }
+
+        Uri uri = Util.BuildUri(new("/predictions"), queryParams);
+        HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Get, uri, session).ConfigureAwait(false);
+        return await response.ReadFromJsonAsync<ResponseData<Prediction>>(TwitchApi.SerializerOptions).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Creates a prediction that viewers in the broadcaster's channel can participate in.
+    /// </summary>
+    /// <param name="session">The <see cref="TwitchSession"/> to authorize the request.</param>
+    /// <param name="parameters">The <see cref="PredictionCreationParameters"/> with the request parameters.</param>
+    /// <returns>A <see cref="ResponseData{TDataType}"/> with elements of type <see cref="Prediction"/> containing the response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> or <paramref name="parameters"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><see cref="PredictionCreationParameters.BroadcasterId"/>, <see cref="PredictionCreationParameters.Title"/>, or a <see cref="PredictionCreationOutcome.Title"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="ArgumentNullException"><see cref="PredictionCreationParameters.PredictionWindowSeconds"/> is <see langword="null"/>; <see cref="PredictionCreationParameters.Outcomes"/> is <see langword="null"/> or empty.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><see cref="PredictionCreationParameters.Title"/> has more than 45 characters; <see cref="PredictionCreationParameters.Outcomes"/> has less than 2 or more than 10 elements; a <see cref="PredictionCreationOutcome.Title"/> has more than 25 characters.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="TwitchSession.Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TwitchScopeMissingException"><paramref name="session"/> does not have the scope <see cref="Scope.ChannelManagePredictions"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Response Codes:
+    /// <list type="table">
+    /// <item>
+    /// <term>200 OK</term>
+    /// <description>Successfully created the prediction.</description>
+    /// </item>
+    /// <item>
+    /// <term>400 Bad Request</term>
+    /// <description>The described parameter was missing or invalid.</description>
+    /// </item>
+    /// <item>
+    /// <term>401 Unauthorized</term>
+    /// <description>The OAuth token was invalid for this request due to the specified reason.</description>
+    /// </item>
+    /// <item>
+    /// <term>403 Forbidden</term>
+    /// <description>The broadcaster is not allowed to create predictions.</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly", Justification = "Intentional")]
+    public static async Task<ResponseData<Prediction>?> CreatePrediction(TwitchSession session, PredictionCreationParameters parameters)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
+        }
+
+        if (parameters is null)
+        {
+            throw new ArgumentNullException(nameof(parameters)).Log(TwitchApi.GetLogger());
+        }
+
+        session.RequireToken(Scope.ChannelManagePredictions);
+
+        if (string.IsNullOrWhiteSpace(parameters.BroadcasterId))
+        {
+            throw new ArgumentNullException(nameof(parameters.BroadcasterId)).Log(TwitchApi.GetLogger());
+        }
+
+        if (string.IsNullOrWhiteSpace(parameters.Title))
+        {
+            throw new ArgumentNullException(nameof(parameters.Title)).Log(TwitchApi.GetLogger());
+        }
+
+        if (!parameters.PredictionWindowSeconds.HasValue)
+        {
+            throw new ArgumentNullException(nameof(parameters.PredictionWindowSeconds)).Log(TwitchApi.GetLogger());
+        }
+
+        if (parameters.Outcomes is null || !parameters.Outcomes.Any())
+        {
+            throw new ArgumentNullException(nameof(parameters.Outcomes)).Log(TwitchApi.GetLogger());
+        }
+
+        if (parameters.Title.Length > 45)
+        {
+            throw new ArgumentOutOfRangeException(nameof(parameters.Title), parameters.Title.Length, "must be 45 characters or less").Log(TwitchApi.GetLogger());
+        }
+
+        if (parameters.Outcomes.Count is < 2 or > 10)
+        {
+            throw new ArgumentOutOfRangeException(nameof(parameters.Outcomes), parameters.Outcomes.Count, "must provide 2-10 outcomes").Log(TwitchApi.GetLogger());
+        }
+
+        foreach (PredictionCreationOutcome outcome in parameters.Outcomes)
+        {
+            if (string.IsNullOrWhiteSpace(outcome.Title))
+            {
+                throw new ArgumentNullException(nameof(parameters.Outcomes), "an outcome may not be null, empty, or whitespace").Log(TwitchApi.GetLogger());
+            }
+            else if (outcome.Title.Length > 25)
+            {
+                throw new ArgumentOutOfRangeException(nameof(parameters.Outcomes), outcome.Title, "an outcome length must be <= 25").Log(TwitchApi.GetLogger());
+            }
+        }
+
+        if (Math.Clamp(parameters.PredictionWindowSeconds.Value, 30, 1800) != parameters.PredictionWindowSeconds.Value)
+        {
+            parameters = parameters with { PredictionWindowSeconds = Math.Clamp(parameters.PredictionWindowSeconds.Value, 30, 1800) };
+        }
+
+        using JsonContent content = JsonContent.Create(parameters, options: TwitchApi.SerializerOptions);
+        HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Post, new("/predictions"), session, content).ConfigureAwait(false);
+        return await response.ReadFromJsonAsync<ResponseData<Prediction>>(TwitchApi.SerializerOptions).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Ends an active prediction.
+    /// </summary>
+    /// <param name="session">The <see cref="TwitchSession"/> to authorize the request.</param>
+    /// <param name="parameters">The <see cref="PredictionEndParameters"/> with the request parameters.</param>
+    /// <returns>A <see cref="ResponseData{TDataType}"/> with elements of type <see cref="Prediction"/> containing the response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> or <paramref name="parameters"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException"><see cref="PredictionEndParameters.BroadcasterId"/>, <see cref="PredictionEndParameters.Id"/>, or <see cref="PredictionEndParameters.Status"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><see cref="PredictionEndParameters.Status"/> is not a valid value.</exception>
+    /// <exception cref="ArgumentNullException"><see cref="PredictionEndParameters.WinningOutcomeId"/> is <see langword="null"/> when <see cref="PredictionEndParameters.Status"/> is <see cref="PredictionStatus.Resolved"/>.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="TwitchSession.Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TwitchScopeMissingException"><paramref name="session"/> does not have the scope <see cref="Scope.ChannelManagePredictions"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Response Codes:
+    /// <list type="table">
+    /// <item>
+    /// <term>200 OK</term>
+    /// <description>Successfully updated the prediction.</description>
+    /// </item>
+    /// <item>
+    /// <term>400 Bad Request</term>
+    /// <description>The described parameter was missing or invalid.</description>
+    /// </item>
+    /// <item>
+    /// <term>401 Unauthorized</term>
+    /// <description>The OAuth token was invalid for this request due to the specified reason.</description>
+    /// </item>
+    /// <item>
+    /// <term>403 Forbidden</term>
+    /// <description>The broadcaster is not allowed to end predictions.</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly", Justification = "Intentional")]
+    public static async Task<ResponseData<Prediction>?> EndPrediction(TwitchSession session, PredictionEndParameters parameters)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
+        }
+
+        if (parameters is null)
+        {
+            throw new ArgumentNullException(nameof(parameters)).Log(TwitchApi.GetLogger());
+        }
+
+        session.RequireToken(Scope.ChannelManagePredictions);
+
+        if (string.IsNullOrWhiteSpace(parameters.BroadcasterId))
+        {
+            throw new ArgumentNullException(nameof(parameters.BroadcasterId)).Log(TwitchApi.GetLogger());
+        }
+
+        if (parameters.Id == null || parameters.Id == Guid.Empty)
+        {
+            throw new ArgumentNullException(nameof(parameters.Id)).Log(TwitchApi.GetLogger());
+        }
+
+        if (parameters.Status is null || parameters.Status == PredictionStatus.Invalid || parameters.Status == PredictionStatus.Active)
+        {
+            throw new ArgumentOutOfRangeException(nameof(parameters.Status), parameters.Status, "must be one of Resolved, Canceled, or Locked").Log(TwitchApi.GetLogger());
+        }
+
+        if (parameters.Status == PredictionStatus.Resolved && (parameters.WinningOutcomeId == null || parameters.WinningOutcomeId == Guid.Empty))
+        {
+            throw new ArgumentNullException(nameof(parameters.WinningOutcomeId), "must be provided when resolving a prediction").Log(TwitchApi.GetLogger());
+        }
+
+        using JsonContent content = JsonContent.Create(parameters, options: TwitchApi.SerializerOptions);
+        HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Patch, new("/predictions"), session, content).ConfigureAwait(false);
+        return await response.ReadFromJsonAsync<ResponseData<Prediction>>(TwitchApi.SerializerOptions).ConfigureAwait(false);
+    }
+}

--- a/StreamActions.Twitch/Api/Predictions/Prediction.cs
+++ b/StreamActions.Twitch/Api/Predictions/Prediction.cs
@@ -209,7 +209,7 @@ public sealed record Prediction
             throw new ArgumentOutOfRangeException(nameof(id), id.Count(), "must have a count <= 25").Log(TwitchApi.GetLogger());
         }
 
-        session.RequireToken(Scope.ChannelReadPredictions, Scope.ChannelManagePredictions);
+        session.RequireUserToken(Scope.ChannelReadPredictions, Scope.ChannelManagePredictions);
 
         first = Math.Clamp(first, 1, 25);
 
@@ -291,7 +291,7 @@ public sealed record Prediction
             throw new ArgumentNullException(nameof(parameters)).Log(TwitchApi.GetLogger());
         }
 
-        session.RequireToken(Scope.ChannelManagePredictions);
+        session.RequireUserToken(Scope.ChannelManagePredictions);
 
         if (string.IsNullOrWhiteSpace(parameters.BroadcasterId))
         {
@@ -393,7 +393,7 @@ public sealed record Prediction
             throw new ArgumentNullException(nameof(parameters)).Log(TwitchApi.GetLogger());
         }
 
-        session.RequireToken(Scope.ChannelManagePredictions);
+        session.RequireUserToken(Scope.ChannelManagePredictions);
 
         if (string.IsNullOrWhiteSpace(parameters.BroadcasterId))
         {

--- a/StreamActions.Twitch/Api/Predictions/PredictionCreationOutcome.cs
+++ b/StreamActions.Twitch/Api/Predictions/PredictionCreationOutcome.cs
@@ -1,0 +1,33 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Predictions;
+
+/// <summary>
+/// Represents a possible outcome when creating a prediction.
+/// </summary>
+public sealed record PredictionCreationOutcome
+{
+    /// <summary>
+    /// The text of one of the outcomes that the viewer may select.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+}

--- a/StreamActions.Twitch/Api/Predictions/PredictionCreationParameters.cs
+++ b/StreamActions.Twitch/Api/Predictions/PredictionCreationParameters.cs
@@ -1,0 +1,51 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Predictions;
+
+/// <summary>
+/// Represents the parameters for creating a prediction.
+/// </summary>
+public sealed record PredictionCreationParameters
+{
+    /// <summary>
+    /// The ID of the broadcaster that's running the prediction.
+    /// </summary>
+    [JsonPropertyName("broadcaster_id")]
+    public string? BroadcasterId { get; init; }
+
+    /// <summary>
+    /// The question that the broadcaster is asking.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// The list of possible outcomes that the viewers may choose from.
+    /// </summary>
+    [JsonPropertyName("outcomes")]
+    public IReadOnlyList<PredictionCreationOutcome>? Outcomes { get; init; }
+
+    /// <summary>
+    /// The length of time (in seconds) that the prediction will run for.
+    /// </summary>
+    [JsonPropertyName("prediction_window")]
+    public int? PredictionWindowSeconds { get; init; }
+}

--- a/StreamActions.Twitch/Api/Predictions/PredictionEndParameters.cs
+++ b/StreamActions.Twitch/Api/Predictions/PredictionEndParameters.cs
@@ -1,0 +1,56 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Predictions;
+
+/// <summary>
+/// Represents the parameters for ending a prediction.
+/// </summary>
+public sealed record PredictionEndParameters
+{
+    /// <summary>
+    /// The ID of the broadcaster that's running the prediction.
+    /// </summary>
+    [JsonPropertyName("broadcaster_id")]
+    public string? BroadcasterId { get; init; }
+
+    /// <summary>
+    /// The ID of the prediction to update.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public Guid? Id { get; init; }
+
+    /// <summary>
+    /// The status to set the prediction to.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public Prediction.PredictionStatus? Status { get; init; }
+
+    /// <summary>
+    /// The ID of the winning outcome.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Required if <see cref="Status"/> is <see cref="Prediction.PredictionStatus.Resolved"/>.
+    /// </para>
+    /// </remarks>
+    [JsonPropertyName("winning_outcome_id")]
+    public Guid? WinningOutcomeId { get; init; }
+}

--- a/StreamActions.Twitch/Api/Predictions/PredictionOutcome.cs
+++ b/StreamActions.Twitch/Api/Predictions/PredictionOutcome.cs
@@ -1,0 +1,84 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using StreamActions.Common.Json.Serialization;
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Predictions;
+
+/// <summary>
+/// Represents a possible outcome for a prediction.
+/// </summary>
+public sealed record PredictionOutcome
+{
+    /// <summary>
+    /// An ID that identifies this outcome.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public Guid? Id { get; init; }
+
+    /// <summary>
+    /// The outcome's text.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// The number of unique viewers that chose this outcome.
+    /// </summary>
+    [JsonPropertyName("users")]
+    public int? Users { get; init; }
+
+    /// <summary>
+    /// The number of Channel Points spent by viewers on this outcome.
+    /// </summary>
+    [JsonPropertyName("channel_points")]
+    public int? ChannelPoints { get; init; }
+
+    /// <summary>
+    /// A list of viewers who were the top predictors.
+    /// </summary>
+    [JsonPropertyName("top_predictors")]
+    public IReadOnlyList<PredictionPredictor>? TopPredictors { get; init; }
+
+    /// <summary>
+    /// The color that visually identifies this outcome in the UX.
+    /// </summary>
+    [JsonPropertyName("color")]
+    public PredictionOutcomeColors? Color { get; init; }
+
+    /// <summary>
+    /// The colors that visually identify an outcome in the UX.
+    /// </summary>
+    [JsonConverter(typeof(JsonUpperCaseEnumConverter<PredictionOutcomeColors>))]
+    public enum PredictionOutcomeColors
+    {
+        /// <summary>
+        /// Something went wrong while determining the state.
+        /// </summary>
+        Invalid,
+        /// <summary>
+        /// Blue.
+        /// </summary>
+        Blue,
+        /// <summary>
+        /// Pink.
+        /// </summary>
+        Pink
+    }
+}

--- a/StreamActions.Twitch/Api/Predictions/PredictionPredictor.cs
+++ b/StreamActions.Twitch/Api/Predictions/PredictionPredictor.cs
@@ -1,0 +1,57 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Predictions;
+
+/// <summary>
+/// Represents a viewer who made a prediction.
+/// </summary>
+public sealed record PredictionPredictor
+{
+    /// <summary>
+    /// An ID that identifies the viewer.
+    /// </summary>
+    [JsonPropertyName("user_id")]
+    public string? UserId { get; init; }
+
+    /// <summary>
+    /// The viewer's display name.
+    /// </summary>
+    [JsonPropertyName("user_name")]
+    public string? UserName { get; init; }
+
+    /// <summary>
+    /// The viewer's login name.
+    /// </summary>
+    [JsonPropertyName("user_login")]
+    public string? UserLogin { get; init; }
+
+    /// <summary>
+    /// The number of Channel Points the viewer spent.
+    /// </summary>
+    [JsonPropertyName("channel_points_used")]
+    public int? ChannelPointsUsed { get; init; }
+
+    /// <summary>
+    /// The number of Channel Points distributed to the viewer.
+    /// </summary>
+    [JsonPropertyName("channel_points_won")]
+    public int? ChannelPointsWon { get; init; }
+}

--- a/StreamActions.Twitch/OAuth/Token.cs
+++ b/StreamActions.Twitch/OAuth/Token.cs
@@ -104,7 +104,7 @@ public sealed record Token : JsonApiResponse
             throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
         }
 
-        session.RequireToken();
+        session.RequireUserToken();
 
         if (string.IsNullOrWhiteSpace(session.Token?.Refresh))
         {
@@ -177,7 +177,7 @@ public sealed record Token : JsonApiResponse
             throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
         }
 
-        session.RequireToken();
+        session.RequireUserToken();
 
         using FormUrlEncodedContent content = new(new Dictionary<string, string>() { { "client_id", TwitchApi.ClientId ?? "" }, { "token", session.Token?.OAuth ?? "" } });
         HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Post, new(baseAddress), TwitchSession.Empty, content).ConfigureAwait(false);

--- a/StreamActions.Twitch/OAuth/UserInfo.cs
+++ b/StreamActions.Twitch/OAuth/UserInfo.cs
@@ -135,7 +135,7 @@ public sealed record UserInfo : JsonApiResponse
             throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
         }
 
-        session.RequireToken(Scope.OpenID);
+        session.RequireUserToken(Scope.OpenID);
 
         baseAddress ??= Token._openIdConnectConfiguration.Value.UserInfoEndpoint;
 


### PR DESCRIPTION
Implemented the Twitch Predictions API endpoints and models. Included fixes for existing build errors in the project related to JsonIgnoreCondition and missing methods in TwitchSession. Corrected the scope validation logic to properly handle multiple optional scopes (OR logic) as required by the Twitch API and suggested by AGENTS.md.

---
*PR created automatically by Jules for task [2878958749813487941](https://jules.google.com/task/2878958749813487941) started by @gmt2001*