### PR TITLE
feat(api): Add Twitch API Extensions endpoints

### DIFF
--- a/StreamActions.Twitch/Api/Common/TwitchSession.cs
+++ b/StreamActions.Twitch/Api/Common/TwitchSession.cs
@@ -65,6 +65,29 @@ public sealed record TwitchSession : IDisposable
     public void Dispose() => this._refreshLock.Close();
 
     /// <summary>
+    /// Checks if a JWT token is present.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"><see cref="Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.Jwt"/>.</exception>
+    public void RequireJwtToken()
+    {
+        if (this.Token is null)
+        {
+            throw new InvalidOperationException(nameof(this.Token) + " is null.").Log(TwitchApi.GetLogger());
+        }
+
+        if (string.IsNullOrWhiteSpace(this.Token.OAuth))
+        {
+            throw new InvalidOperationException(nameof(this.Token.OAuth) + " is null, empty, or whitespace.").Log(TwitchApi.GetLogger());
+        }
+
+        if (this.Token.Type is not TwitchToken.TokenType.Jwt)
+        {
+            throw new TokenTypeException(Enum.GetName(TwitchToken.TokenType.Jwt), Enum.GetName(this.Token.Type ?? TwitchToken.TokenType.Unknown)).Log(TwitchApi.GetLogger());
+        }
+    }
+
+    /// <summary>
     /// Checks if an app token is present.
     /// </summary>
     /// <exception cref="InvalidOperationException"><see cref="Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>

--- a/StreamActions.Twitch/Api/Common/TwitchToken.cs
+++ b/StreamActions.Twitch/Api/Common/TwitchToken.cs
@@ -56,7 +56,12 @@ public sealed record TwitchToken
         /// <summary>
         /// An App token.
         /// </summary>
-        App
+        App,
+
+        /// <summary>
+        /// A JWT token.
+        /// </summary>
+        Jwt
     }
 
     #endregion Public Enums

--- a/StreamActions.Twitch/Api/Extensions/Extension.cs
+++ b/StreamActions.Twitch/Api/Extensions/Extension.cs
@@ -1,0 +1,296 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using StreamActions.Common;
+using StreamActions.Common.Exceptions;
+using StreamActions.Common.Extensions;
+using StreamActions.Twitch.Api.Common;
+using StreamActions.Common.Logger;
+using System.Collections.Specialized;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Sends and represents a response element for a request for extensions.
+/// </summary>
+public sealed record Extension
+{
+    /// <summary>
+    /// The name of the user or organization that owns the extension.
+    /// </summary>
+    [JsonPropertyName("author_name")]
+    public string? AuthorName { get; init; }
+
+    /// <summary>
+    /// A Boolean value that determines whether the extension has features that use Bits.
+    /// </summary>
+    [JsonPropertyName("bits_enabled")]
+    public bool? BitsEnabled { get; init; }
+
+    /// <summary>
+    /// A Boolean value that determines whether a user can install the extension on their channel.
+    /// </summary>
+    [JsonPropertyName("can_install")]
+    public bool? CanInstall { get; init; }
+
+    /// <summary>
+    /// The location of where the extension's configuration is stored.
+    /// </summary>
+    [JsonPropertyName("configuration_location")]
+    public string? ConfigurationLocation { get; init; }
+
+    /// <summary>
+    /// A longer description of the extension. It appears on the details page.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// A URL to the extension's Terms of Service.
+    /// </summary>
+    [JsonPropertyName("eula_tos_url")]
+    public string? EulaTosUrl { get; init; }
+
+    /// <summary>
+    /// A Boolean value that determines whether the extension can communicate with the installed channel's chat.
+    /// </summary>
+    [JsonPropertyName("has_chat_support")]
+    public bool? HasChatSupport { get; init; }
+
+    /// <summary>
+    /// A URL to the default icon that's displayed in the Extensions directory.
+    /// </summary>
+    [JsonPropertyName("icon_url")]
+    public string? IconUrl { get; init; }
+
+    /// <summary>
+    /// A dictionary that contains URLs to different sizes of the default icon.
+    /// </summary>
+    [JsonPropertyName("icon_urls")]
+    public IReadOnlyDictionary<string, string>? IconUrls { get; init; }
+
+    /// <summary>
+    /// The extension's ID.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    /// <summary>
+    /// The extension's name.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// A URL to the extension's privacy policy.
+    /// </summary>
+    [JsonPropertyName("privacy_policy_url")]
+    public string? PrivacyPolicyUrl { get; init; }
+
+    /// <summary>
+    /// A Boolean value that determines whether the extension wants to explicitly ask viewers to link their Twitch identity.
+    /// </summary>
+    [JsonPropertyName("request_identity_link")]
+    public bool? RequestIdentityLink { get; init; }
+
+    /// <summary>
+    /// A list of URLs to screenshots that are shown in the Extensions marketplace.
+    /// </summary>
+    [JsonPropertyName("screenshot_urls")]
+    public IReadOnlyList<string>? ScreenshotUrls { get; init; }
+
+    /// <summary>
+    /// The extension's state.
+    /// </summary>
+    [JsonPropertyName("state")]
+    public string? State { get; init; }
+
+    /// <summary>
+    /// Indicates whether the extension can view the user's subscription level on the channel that the extension is installed on.
+    /// </summary>
+    [JsonPropertyName("subscriptions_support_level")]
+    public string? SubscriptionsSupportLevel { get; init; }
+
+    /// <summary>
+    /// A short description of the extension that streamers see when hovering over the discovery splash screen in the Extensions manager.
+    /// </summary>
+    [JsonPropertyName("summary")]
+    public string? Summary { get; init; }
+
+    /// <summary>
+    /// The email address that users use to get support for the extension.
+    /// </summary>
+    [JsonPropertyName("support_email")]
+    public string? SupportEmail { get; init; }
+
+    /// <summary>
+    /// The extension's version number.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// A brief description displayed on the channel to explain how the extension works.
+    /// </summary>
+    [JsonPropertyName("viewer_summary")]
+    public string? ViewerSummary { get; init; }
+
+    /// <summary>
+    /// Describes all views-related information such as how the extension is displayed on mobile devices.
+    /// </summary>
+    [JsonPropertyName("views")]
+    public ExtensionViews? Views { get; init; }
+
+    /// <summary>
+    /// Allowlisted configuration URLs for displaying the extension.
+    /// </summary>
+    [JsonPropertyName("allowlisted_config_urls")]
+    public IReadOnlyList<string>? AllowlistedConfigUrls { get; init; }
+
+    /// <summary>
+    /// Allowlisted panel URLs for displaying the extension.
+    /// </summary>
+    [JsonPropertyName("allowlisted_panel_urls")]
+    public IReadOnlyList<string>? AllowlistedPanelUrls { get; init; }
+
+    /// <summary>
+    /// Gets information about an extension.
+    /// </summary>
+    /// <param name="session">The <see cref="TwitchSession"/> to authorize the request. Requires a signed JSON Web Token (JWT) created by an Extension Backend Service (EBS).</param>
+    /// <param name="extensionId">The ID of the extension to get.</param>
+    /// <param name="extensionVersion">The version of the extension to get. If not specified, it returns the latest, released version.</param>
+    /// <returns>A <see cref="ResponseData{TDataType}"/> with elements of type <see cref="Extension"/> containing the response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>; <paramref name="extensionId"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="TwitchSession.Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.Jwt"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Response Codes:
+    /// <list type="table">
+    /// <item>
+    /// <term>200 OK</term>
+    /// <description>Successfully retrieved the list of extensions.</description>
+    /// </item>
+    /// <item>
+    /// <term>400 Bad Request</term>
+    /// <description>The described parameter was missing or invalid.</description>
+    /// </item>
+    /// <item>
+    /// <term>401 Unauthorized</term>
+    /// <description>The JWT token was invalid for this request due to the specified reason.</description>
+    /// </item>
+    /// <item>
+    /// <term>404 Not Found</term>
+    /// <description>The extension in the extension_id query parameter was not found.</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public static async Task<ResponseData<Extension>?> GetExtensions(TwitchSession session, string extensionId, string? extensionVersion = null)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
+        }
+
+        session.RequireJwtToken();
+
+        if (string.IsNullOrWhiteSpace(extensionId))
+        {
+            throw new ArgumentNullException(nameof(extensionId)).Log(TwitchApi.GetLogger());
+        }
+
+        NameValueCollection queryParams = new()
+        {
+            { "extension_id", extensionId }
+        };
+
+        if (!string.IsNullOrWhiteSpace(extensionVersion))
+        {
+            queryParams.Add("extension_version", extensionVersion);
+        }
+
+        Uri uri = Util.BuildUri(new("/extensions"), queryParams);
+        HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Get, uri, session).ConfigureAwait(false);
+        return await response.ReadFromJsonAsync<ResponseData<Extension>>(TwitchApi.SerializerOptions).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Gets information about a released extension. Returns the extension if its state is Released.
+    /// </summary>
+    /// <param name="session">The <see cref="TwitchSession"/> to authorize the request.</param>
+    /// <param name="extensionId">The ID of the extension to get.</param>
+    /// <param name="extensionVersion">The version of the extension to get. If not specified, it returns the latest version.</param>
+    /// <returns>A <see cref="ResponseData{TDataType}"/> with elements of type <see cref="Extension"/> containing the response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>; <paramref name="extensionId"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="TwitchSession.Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.User"/> or <see cref="TwitchToken.TokenType.App"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Response Codes:
+    /// <list type="table">
+    /// <item>
+    /// <term>200 OK</term>
+    /// <description>Successfully retrieved the extension.</description>
+    /// </item>
+    /// <item>
+    /// <term>400 Bad Request</term>
+    /// <description>The described parameter was missing or invalid.</description>
+    /// </item>
+    /// <item>
+    /// <term>401 Unauthorized</term>
+    /// <description>The OAuth token was invalid for this request due to the specified reason.</description>
+    /// </item>
+    /// <item>
+    /// <term>404 Not Found</term>
+    /// <description>The extension specified in the extension_id query parameter was not found or is not released.</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public static async Task<ResponseData<Extension>?> GetReleasedExtensions(TwitchSession session, string extensionId, string? extensionVersion = null)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
+        }
+
+        session.RequireUserOrAppToken();
+
+        if (string.IsNullOrWhiteSpace(extensionId))
+        {
+            throw new ArgumentNullException(nameof(extensionId)).Log(TwitchApi.GetLogger());
+        }
+
+        NameValueCollection queryParams = new()
+        {
+            { "extension_id", extensionId }
+        };
+
+        if (!string.IsNullOrWhiteSpace(extensionVersion))
+        {
+            queryParams.Add("extension_version", extensionVersion);
+        }
+
+        Uri uri = Util.BuildUri(new("/extensions/released"), queryParams);
+        HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Get, uri, session).ConfigureAwait(false);
+        return await response.ReadFromJsonAsync<ResponseData<Extension>>(TwitchApi.SerializerOptions).ConfigureAwait(false);
+    }
+}

--- a/StreamActions.Twitch/Api/Extensions/ExtensionBitsProduct.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionBitsProduct.cs
@@ -1,0 +1,128 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using StreamActions.Common;
+using StreamActions.Common.Exceptions;
+using StreamActions.Common.Extensions;
+using StreamActions.Twitch.Api.Common;
+using StreamActions.Common.Logger;
+using System.Collections.Specialized;
+using System.Net.Http.Json;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Contains extension bits products methods.
+/// </summary>
+public sealed record ExtensionBitsProduct
+{
+    /// <summary>
+    /// Gets the list of Bits products that belongs to the extension.
+    /// </summary>
+    /// <param name="session">The <see cref="TwitchSession"/> to authorize the request. Must be for an App Access Token.</param>
+    /// <param name="shouldIncludeAll">A Boolean value that determines whether to include disabled or expired Bits products in the response.</param>
+    /// <returns>A <see cref="ResponseData{TDataType}"/> with elements of type <see cref="ExtensionProductData"/> containing the response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="TwitchSession.Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.App"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Response Codes:
+    /// <list type="table">
+    /// <item>
+    /// <term>200 OK</term>
+    /// <description>Successfully retrieved the list of products.</description>
+    /// </item>
+    /// <item>
+    /// <term>400 Bad Request</term>
+    /// <description>The ID in the Client-Id header must belong to an extension.</description>
+    /// </item>
+    /// <item>
+    /// <term>401 Unauthorized</term>
+    /// <description>The OAuth token was invalid for this request due to the specified reason.</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public static async Task<ResponseData<ExtensionProductData>?> GetExtensionBitsProducts(TwitchSession session, bool shouldIncludeAll = false)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
+        }
+
+        session.RequireAppToken();
+
+        NameValueCollection queryParams = new();
+        if (shouldIncludeAll)
+        {
+            queryParams.Add("should_include_all", "true");
+        }
+
+        Uri uri = Util.BuildUri(new("/bits/extensions"), queryParams);
+        HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Get, uri, session).ConfigureAwait(false);
+        return await response.ReadFromJsonAsync<ResponseData<ExtensionProductData>>(TwitchApi.SerializerOptions).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Adds or updates a Bits product that the extension created.
+    /// </summary>
+    /// <param name="session">The <see cref="TwitchSession"/> to authorize the request. Must be for an App Access Token.</param>
+    /// <param name="parameters">The <see cref="UpdateExtensionBitsProductParameters"/> for the request.</param>
+    /// <returns>A <see cref="ResponseData{TDataType}"/> with elements of type <see cref="ExtensionProductData"/> containing the response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> or <paramref name="parameters"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="TwitchSession.Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.App"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Response Codes:
+    /// <list type="table">
+    /// <item>
+    /// <term>200 OK</term>
+    /// <description>Successfully created the product.</description>
+    /// </item>
+    /// <item>
+    /// <term>400 Bad Request</term>
+    /// <description>The described parameter was missing or invalid.</description>
+    /// </item>
+    /// <item>
+    /// <term>401 Unauthorized</term>
+    /// <description>The OAuth token was invalid for this request due to the specified reason.</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public static async Task<ResponseData<ExtensionProductData>?> UpdateExtensionBitsProduct(TwitchSession session, UpdateExtensionBitsProductParameters parameters)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
+        }
+
+        if (parameters is null)
+        {
+            throw new ArgumentNullException(nameof(parameters)).Log(TwitchApi.GetLogger());
+        }
+
+        session.RequireAppToken();
+
+        using JsonContent content = JsonContent.Create(parameters, options: TwitchApi.SerializerOptions);
+        HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Put, new("/bits/extensions"), session, content).ConfigureAwait(false);
+        return await response.ReadFromJsonAsync<ResponseData<ExtensionProductData>>(TwitchApi.SerializerOptions).ConfigureAwait(false);
+    }
+}

--- a/StreamActions.Twitch/Api/Extensions/ExtensionChatMessage.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionChatMessage.cs
@@ -1,0 +1,92 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using StreamActions.Common;
+using StreamActions.Common.Exceptions;
+using StreamActions.Common.Extensions;
+using StreamActions.Common.Net;
+using StreamActions.Twitch.Api.Common;
+using StreamActions.Common.Logger;
+using System.Collections.Specialized;
+using System.Net.Http.Json;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Contains extension chat message methods.
+/// </summary>
+public sealed record ExtensionChatMessage
+{
+    /// <summary>
+    /// Sends a message to the specified broadcaster’s chat room.
+    /// </summary>
+    /// <param name="session">The <see cref="TwitchSession"/> to authorize the request. Requires a signed JSON Web Token (JWT) created by an Extension Backend Service (EBS).</param>
+    /// <param name="broadcasterId">The ID of the broadcaster that has activated the extension.</param>
+    /// <param name="parameters">The <see cref="SendExtensionChatMessageParameters"/> for the request.</param>
+    /// <returns>A <see cref="JsonApiResponse"/> containing the response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> or <paramref name="parameters"/> is <see langword="null"/>; <paramref name="broadcasterId"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="TwitchSession.Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.Jwt"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Response Codes:
+    /// <list type="table">
+    /// <item>
+    /// <term>204 No Content</term>
+    /// <description>Successfully sent the chat message.</description>
+    /// </item>
+    /// <item>
+    /// <term>400 Bad Request</term>
+    /// <description>The described parameter was missing or invalid.</description>
+    /// </item>
+    /// <item>
+    /// <term>401 Unauthorized</term>
+    /// <description>The JWT token was invalid for this request due to the specified reason.</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public static async Task<JsonApiResponse?> SendExtensionChatMessage(TwitchSession session, string broadcasterId, SendExtensionChatMessageParameters parameters)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
+        }
+
+        if (parameters is null)
+        {
+            throw new ArgumentNullException(nameof(parameters)).Log(TwitchApi.GetLogger());
+        }
+
+        if (string.IsNullOrWhiteSpace(broadcasterId))
+        {
+            throw new ArgumentNullException(nameof(broadcasterId)).Log(TwitchApi.GetLogger());
+        }
+
+        session.RequireJwtToken();
+
+        NameValueCollection queryParams = new()
+        {
+            { "broadcaster_id", broadcasterId }
+        };
+
+        using JsonContent content = JsonContent.Create(parameters, options: TwitchApi.SerializerOptions);
+        HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Post, Util.BuildUri(new("/extensions/chat"), queryParams), session, content).ConfigureAwait(false);
+        return await response.ReadFromJsonAsync<JsonApiResponse>(TwitchApi.SerializerOptions).ConfigureAwait(false);
+    }
+}

--- a/StreamActions.Twitch/Api/Extensions/ExtensionComponentView.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionComponentView.cs
@@ -1,0 +1,69 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Describes how the extension is rendered if the extension may be activated as a video-component extension.
+/// </summary>
+public sealed record ExtensionComponentView
+{
+    /// <summary>
+    /// The HTML file that is shown to viewers on the channel page when the extension is activated in a Video - Component slot.
+    /// </summary>
+    [JsonPropertyName("viewer_url")]
+    public string? ViewerUrl { get; init; }
+
+    /// <summary>
+    /// The width value of the ratio.
+    /// </summary>
+    [JsonPropertyName("aspect_ratio_x")]
+    public int? AspectRatioX { get; init; }
+
+    /// <summary>
+    /// The height value of the ratio.
+    /// </summary>
+    [JsonPropertyName("aspect_ratio_y")]
+    public int? AspectRatioY { get; init; }
+
+    /// <summary>
+    /// A Boolean value that determines whether to apply CSS zoom.
+    /// </summary>
+    [JsonPropertyName("autoscale")]
+    public bool? Autoscale { get; init; }
+
+    /// <summary>
+    /// The base width, in pixels, of the extension to use when scaling.
+    /// </summary>
+    [JsonPropertyName("scale_pixels")]
+    public int? ScalePixels { get; init; }
+
+    /// <summary>
+    /// The height as a percent of the maximum height of a video component extension. Values are between 1% - 100%.
+    /// </summary>
+    [JsonPropertyName("target_height")]
+    public int? TargetHeight { get; init; }
+
+    /// <summary>
+    /// A Boolean value that determines whether the extension can link to non-Twitch domains.
+    /// </summary>
+    [JsonPropertyName("can_link_external_content")]
+    public bool? CanLinkExternalContent { get; init; }
+}

--- a/StreamActions.Twitch/Api/Extensions/ExtensionConfigView.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionConfigView.cs
@@ -1,0 +1,39 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Describes the view that is shown to broadcasters while they are configuring your extension within the Extension Manager.
+/// </summary>
+public sealed record ExtensionConfigView
+{
+    /// <summary>
+    /// The HTML file shown to broadcasters while they are configuring your extension within the Extension Manager.
+    /// </summary>
+    [JsonPropertyName("viewer_url")]
+    public string? ViewerUrl { get; init; }
+
+    /// <summary>
+    /// A Boolean value that determines whether the extension can link to non-Twitch domains.
+    /// </summary>
+    [JsonPropertyName("can_link_external_content")]
+    public bool? CanLinkExternalContent { get; init; }
+}

--- a/StreamActions.Twitch/Api/Extensions/ExtensionConfigurationSegment.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionConfigurationSegment.cs
@@ -1,0 +1,193 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using StreamActions.Common;
+using StreamActions.Common.Exceptions;
+using StreamActions.Common.Extensions;
+using StreamActions.Common.Net;
+using StreamActions.Twitch.Api.Common;
+using StreamActions.Common.Logger;
+using System.Collections.Specialized;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Contains extension configuration segment data and methods to get and set segments.
+/// </summary>
+public sealed record ExtensionConfigurationSegment
+{
+    /// <summary>
+    /// The type of segment. Possible values are: broadcaster, developer, global.
+    /// </summary>
+    [JsonPropertyName("segment")]
+    public string? Segment { get; init; }
+
+    /// <summary>
+    /// The ID of the broadcaster that installed the extension. The object includes this field only if the segment query parameter is set to developer or broadcaster.
+    /// </summary>
+    [JsonPropertyName("broadcaster_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? BroadcasterId { get; init; }
+
+    /// <summary>
+    /// The contents of the segment. This string may be a plain-text string or a string-encoded JSON object.
+    /// </summary>
+    [JsonPropertyName("content")]
+    public string? Content { get; init; }
+
+    /// <summary>
+    /// The version number that identifies this definition of the segment’s data.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// Gets the specified configuration segment from the specified extension.
+    /// </summary>
+    /// <param name="session">The <see cref="TwitchSession"/> to authorize the request. Requires a signed JSON Web Token (JWT) created by an Extension Backend Service (EBS).</param>
+    /// <param name="extensionId">The ID of the extension that contains the configuration segment you want to get.</param>
+    /// <param name="segment">The type of configuration segment to get. Possible case-sensitive values are: broadcaster, developer, global. You may specify one or more segments.</param>
+    /// <param name="broadcasterId">The ID of the broadcaster that installed the extension. This parameter is required if you set the segment parameter to broadcaster or developer.</param>
+    /// <returns>A <see cref="ResponseData{TDataType}"/> with elements of type <see cref="ExtensionConfigurationSegment"/> containing the response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>; <paramref name="extensionId"/> is <see langword="null"/>, empty, or whitespace; <paramref name="segment"/> is <see langword="null"/> or empty.</exception>
+    /// <exception cref="ArgumentException"><paramref name="broadcasterId"/> is required when <paramref name="segment"/> contains broadcaster or developer.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="TwitchSession.Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.Jwt"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Response Codes:
+    /// <list type="table">
+    /// <item>
+    /// <term>200 OK</term>
+    /// <description>Successfully retrieved the configurations.</description>
+    /// </item>
+    /// <item>
+    /// <term>400 Bad Request</term>
+    /// <description>The described parameter was missing or invalid.</description>
+    /// </item>
+    /// <item>
+    /// <term>401 Unauthorized</term>
+    /// <description>The JWT token was invalid for this request due to the specified reason.</description>
+    /// </item>
+    /// <item>
+    /// <term>429 Too many requests</term>
+    /// <description>The app exceeded the number of requests that it may make per minute.</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public static async Task<ResponseData<ExtensionConfigurationSegment>?> GetExtensionConfigurationSegment(TwitchSession session, string extensionId, IEnumerable<string> segment, string? broadcasterId = null)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
+        }
+
+        session.RequireJwtToken();
+
+        if (string.IsNullOrWhiteSpace(extensionId))
+        {
+            throw new ArgumentNullException(nameof(extensionId)).Log(TwitchApi.GetLogger());
+        }
+
+        if (segment is null || !segment.Any())
+        {
+            throw new ArgumentNullException(nameof(segment)).Log(TwitchApi.GetLogger());
+        }
+
+        List<string> segments = [];
+        foreach (string s in segment)
+        {
+            if (!string.IsNullOrWhiteSpace(s))
+            {
+                segments.Add(s);
+            }
+        }
+
+        if (segments.Contains("broadcaster") || segments.Contains("developer"))
+        {
+            if (string.IsNullOrWhiteSpace(broadcasterId))
+            {
+                throw new ArgumentNullException(nameof(broadcasterId), "broadcaster_id is required if segment is broadcaster or developer.").Log(TwitchApi.GetLogger());
+            }
+        }
+
+        NameValueCollection queryParams = new()
+        {
+            { "extension_id", extensionId },
+            { "segment", segments }
+        };
+
+        if (!string.IsNullOrWhiteSpace(broadcasterId))
+        {
+            queryParams.Add("broadcaster_id", broadcasterId);
+        }
+
+        HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Get, Util.BuildUri(new("/extensions/configurations"), queryParams), session).ConfigureAwait(false);
+        return await response.ReadFromJsonAsync<ResponseData<ExtensionConfigurationSegment>>(TwitchApi.SerializerOptions).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Updates a configuration segment. The segment is limited to 5 KB.
+    /// </summary>
+    /// <param name="session">The <see cref="TwitchSession"/> to authorize the request. Requires a signed JSON Web Token (JWT) created by an Extension Backend Service (EBS).</param>
+    /// <param name="parameters">The <see cref="SetExtensionConfigurationSegmentParameters"/> for the request.</param>
+    /// <returns>A <see cref="JsonApiResponse"/> containing the response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> or <paramref name="parameters"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="TwitchSession.Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.Jwt"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Response Codes:
+    /// <list type="table">
+    /// <item>
+    /// <term>204 No Content</term>
+    /// <description>Successfully updated the configuration.</description>
+    /// </item>
+    /// <item>
+    /// <term>400 Bad Request</term>
+    /// <description>The described parameter was missing or invalid.</description>
+    /// </item>
+    /// <item>
+    /// <term>401 Unauthorized</term>
+    /// <description>The JWT token was invalid for this request due to the specified reason.</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public static async Task<JsonApiResponse?> SetExtensionConfigurationSegment(TwitchSession session, SetExtensionConfigurationSegmentParameters parameters)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
+        }
+
+        if (parameters is null)
+        {
+            throw new ArgumentNullException(nameof(parameters)).Log(TwitchApi.GetLogger());
+        }
+
+        session.RequireJwtToken();
+
+        using JsonContent content = JsonContent.Create(parameters, options: TwitchApi.SerializerOptions);
+        HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Put, new("/extensions/configurations"), session, content).ConfigureAwait(false);
+        return await response.ReadFromJsonAsync<JsonApiResponse>(TwitchApi.SerializerOptions).ConfigureAwait(false);
+    }
+}

--- a/StreamActions.Twitch/Api/Extensions/ExtensionLiveChannel.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionLiveChannel.cs
@@ -1,0 +1,130 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using StreamActions.Common;
+using StreamActions.Common.Exceptions;
+using StreamActions.Common.Extensions;
+using StreamActions.Twitch.Api.Common;
+using StreamActions.Common.Logger;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Sends and represents a response element for a request for extension live channels.
+/// </summary>
+public sealed record ExtensionLiveChannel
+{
+    /// <summary>
+    /// The ID of the broadcaster that is streaming live and has installed or activated the extension.
+    /// </summary>
+    [JsonPropertyName("broadcaster_id")]
+    public string? BroadcasterId { get; init; }
+
+    /// <summary>
+    /// The broadcaster's display name.
+    /// </summary>
+    [JsonPropertyName("broadcaster_name")]
+    public string? BroadcasterName { get; init; }
+
+    /// <summary>
+    /// The name of the category or game being streamed.
+    /// </summary>
+    [JsonPropertyName("game_name")]
+    public string? GameName { get; init; }
+
+    /// <summary>
+    /// The ID of the category or game being streamed.
+    /// </summary>
+    [JsonPropertyName("game_id")]
+    public string? GameId { get; init; }
+
+    /// <summary>
+    /// The title of the broadcaster's stream. May be an empty string if not specified.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>
+    /// Gets a list of broadcasters that are streaming live and have installed or activated the extension.
+    /// </summary>
+    /// <param name="session">The <see cref="TwitchSession"/> to authorize the request.</param>
+    /// <param name="extensionId">The ID of the extension to get. Returns the list of broadcasters that are live and that have installed or activated this extension.</param>
+    /// <param name="first">The specific maximum number of items per page in the response. Maximum: 100.</param>
+    /// <param name="after">The cursor used to get the next page of results.</param>
+    /// <returns>A <see cref="ResponseData{TDataType}"/> with elements of type <see cref="ExtensionLiveChannel"/> containing the response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>; <paramref name="extensionId"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="TwitchSession.Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.App"/> or <see cref="TwitchToken.TokenType.User"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Response Codes:
+    /// <list type="table">
+    /// <item>
+    /// <term>200 OK</term>
+    /// <description>Successfully retrieved the list of broadcasters.</description>
+    /// </item>
+    /// <item>
+    /// <term>400 Bad Request</term>
+    /// <description>The described parameter was missing or invalid.</description>
+    /// </item>
+    /// <item>
+    /// <term>401 Unauthorized</term>
+    /// <description>The OAuth token was invalid for this request due to the specified reason.</description>
+    /// </item>
+    /// <item>
+    /// <term>404 Not Found</term>
+    /// <description>The extension specified in the extension_id query parameter was not found or it's not being used in a live stream.</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public static async Task<ResponseData<ExtensionLiveChannel>?> GetExtensionLiveChannels(TwitchSession session, string extensionId, int first = 20, string? after = null)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
+        }
+
+        session.RequireUserOrAppToken();
+
+        if (string.IsNullOrWhiteSpace(extensionId))
+        {
+            throw new ArgumentNullException(nameof(extensionId)).Log(TwitchApi.GetLogger());
+        }
+
+        first = Math.Clamp(first, 1, 100);
+
+        NameValueCollection queryParams = new()
+        {
+            { "extension_id", extensionId },
+            { "first", first.ToString(CultureInfo.InvariantCulture) }
+        };
+
+        if (!string.IsNullOrWhiteSpace(after))
+        {
+            queryParams.Add("after", after);
+        }
+
+        Uri uri = Util.BuildUri(new("/extensions/live"), queryParams);
+        HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Get, uri, session).ConfigureAwait(false);
+        return await response.ReadFromJsonAsync<ResponseData<ExtensionLiveChannel>>(TwitchApi.SerializerOptions).ConfigureAwait(false);
+    }
+}

--- a/StreamActions.Twitch/Api/Extensions/ExtensionMobileView.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionMobileView.cs
@@ -1,0 +1,33 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Describes how the extension is displayed on mobile devices.
+/// </summary>
+public sealed record ExtensionMobileView
+{
+    /// <summary>
+    /// The HTML file that is shown to viewers on mobile devices.
+    /// </summary>
+    [JsonPropertyName("viewer_url")]
+    public string? ViewerUrl { get; init; }
+}

--- a/StreamActions.Twitch/Api/Extensions/ExtensionPanelView.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionPanelView.cs
@@ -1,0 +1,45 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Describes how the extension is rendered if the extension may be activated as a panel extension.
+/// </summary>
+public sealed record ExtensionPanelView
+{
+    /// <summary>
+    /// The HTML file that is shown to viewers on the channel page when the extension is activated in a Panel slot.
+    /// </summary>
+    [JsonPropertyName("viewer_url")]
+    public string? ViewerUrl { get; init; }
+
+    /// <summary>
+    /// The height, in pixels, of the panel component that the extension is rendered in.
+    /// </summary>
+    [JsonPropertyName("height")]
+    public int? Height { get; init; }
+
+    /// <summary>
+    /// A Boolean value that determines whether the extension can link to non-Twitch domains.
+    /// </summary>
+    [JsonPropertyName("can_link_external_content")]
+    public bool? CanLinkExternalContent { get; init; }
+}

--- a/StreamActions.Twitch/Api/Extensions/ExtensionProductCost.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionProductCost.cs
@@ -1,0 +1,52 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using StreamActions.Common.Json.Serialization;
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Contains details about the digital product's cost in a <see cref="ExtensionProductData"/>.
+/// </summary>
+public sealed record ExtensionProductCost
+{
+    /// <summary>
+    /// The amount exchanged for the digital product.
+    /// </summary>
+    [JsonPropertyName("amount")]
+    public int? Amount { get; init; }
+
+    /// <summary>
+    /// The type of currency exchanged.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public ExtensionProductCostType? Type { get; init; }
+
+    /// <summary>
+    /// The type of currency exchanged.
+    /// </summary>
+    [JsonConverter(typeof(JsonLowerCaseEnumConverter<ExtensionProductCostType>))]
+    public enum ExtensionProductCostType
+    {
+        /// <summary>
+        /// Purchase via bits.
+        /// </summary>
+        Bits
+    }
+}

--- a/StreamActions.Twitch/Api/Extensions/ExtensionProductData.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionProductData.cs
@@ -18,7 +18,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace StreamActions.Twitch.Api.Bits;
+namespace StreamActions.Twitch.Api.Extensions;
 
 /// <summary>
 /// Contains details about the digital product in a <see cref="ExtensionTransaction"/>.

--- a/StreamActions.Twitch/Api/Extensions/ExtensionPubSubMessage.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionPubSubMessage.cs
@@ -1,0 +1,84 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using StreamActions.Common;
+using StreamActions.Common.Exceptions;
+using StreamActions.Common.Extensions;
+using StreamActions.Common.Net;
+using StreamActions.Twitch.Api.Common;
+using StreamActions.Common.Logger;
+using System.Net.Http.Json;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Contains extension PubSub message methods.
+/// </summary>
+public sealed record ExtensionPubSubMessage
+{
+    /// <summary>
+    /// Sends a message to one or more viewers. You can send messages to a specific channel or to all channels where your extension is active.
+    /// </summary>
+    /// <param name="session">The <see cref="TwitchSession"/> to authorize the request. Requires a signed JSON Web Token (JWT) created by an Extension Backend Service (EBS).</param>
+    /// <param name="parameters">The <see cref="SendExtensionPubSubMessageParameters"/> for the request.</param>
+    /// <returns>A <see cref="JsonApiResponse"/> containing the response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> or <paramref name="parameters"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="TwitchSession.Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.Jwt"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Response Codes:
+    /// <list type="table">
+    /// <item>
+    /// <term>204 No Content</term>
+    /// <description>Successfully sent the message.</description>
+    /// </item>
+    /// <item>
+    /// <term>400 Bad Request</term>
+    /// <description>The described parameter was missing or invalid.</description>
+    /// </item>
+    /// <item>
+    /// <term>401 Unauthorized</term>
+    /// <description>The JWT token was invalid for this request due to the specified reason.</description>
+    /// </item>
+    /// <item>
+    /// <term>422 Unprocessable Entity</term>
+    /// <description>The message is too large.</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public static async Task<JsonApiResponse?> SendExtensionPubSubMessage(TwitchSession session, SendExtensionPubSubMessageParameters parameters)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
+        }
+
+        if (parameters is null)
+        {
+            throw new ArgumentNullException(nameof(parameters)).Log(TwitchApi.GetLogger());
+        }
+
+        session.RequireJwtToken();
+
+        using JsonContent content = JsonContent.Create(parameters, options: TwitchApi.SerializerOptions);
+        HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Post, new("/extensions/pubsub"), session, content).ConfigureAwait(false);
+        return await response.ReadFromJsonAsync<JsonApiResponse>(TwitchApi.SerializerOptions).ConfigureAwait(false);
+    }
+}

--- a/StreamActions.Twitch/Api/Extensions/ExtensionRequiredConfiguration.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionRequiredConfiguration.cs
@@ -1,0 +1,93 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using StreamActions.Common;
+using StreamActions.Common.Exceptions;
+using StreamActions.Common.Extensions;
+using StreamActions.Common.Net;
+using StreamActions.Twitch.Api.Common;
+using StreamActions.Common.Logger;
+using System.Collections.Specialized;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Contains extension required configuration methods.
+/// </summary>
+public sealed record ExtensionRequiredConfiguration
+{
+    /// <summary>
+    /// Updates the extension’s required_configuration string.
+    /// </summary>
+    /// <param name="session">The <see cref="TwitchSession"/> to authorize the request. Requires a signed JSON Web Token (JWT) created by an EBS.</param>
+    /// <param name="broadcasterId">The ID of the broadcaster that installed the extension on their channel.</param>
+    /// <param name="parameters">The <see cref="SetExtensionRequiredConfigurationParameters"/> for the request.</param>
+    /// <returns>A <see cref="JsonApiResponse"/> containing the response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> or <paramref name="parameters"/> is <see langword="null"/>; <paramref name="broadcasterId"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="TwitchSession.Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.Jwt"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Response Codes:
+    /// <list type="table">
+    /// <item>
+    /// <term>204 No Content</term>
+    /// <description>Successfully updated the extension's required_configuration string.</description>
+    /// </item>
+    /// <item>
+    /// <term>400 Bad Request</term>
+    /// <description>The described parameter was missing or invalid.</description>
+    /// </item>
+    /// <item>
+    /// <term>401 Unauthorized</term>
+    /// <description>The JWT token was invalid for this request due to the specified reason.</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public static async Task<JsonApiResponse?> SetExtensionRequiredConfiguration(TwitchSession session, string broadcasterId, SetExtensionRequiredConfigurationParameters parameters)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
+        }
+
+        if (parameters is null)
+        {
+            throw new ArgumentNullException(nameof(parameters)).Log(TwitchApi.GetLogger());
+        }
+
+        if (string.IsNullOrWhiteSpace(broadcasterId))
+        {
+            throw new ArgumentNullException(nameof(broadcasterId)).Log(TwitchApi.GetLogger());
+        }
+
+        session.RequireJwtToken();
+
+        NameValueCollection queryParams = new()
+        {
+            { "broadcaster_id", broadcasterId }
+        };
+
+        using JsonContent content = JsonContent.Create(parameters, options: TwitchApi.SerializerOptions);
+        HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Put, Util.BuildUri(new("/extensions/required_configuration"), queryParams), session, content).ConfigureAwait(false);
+        return await response.ReadFromJsonAsync<JsonApiResponse>(TwitchApi.SerializerOptions).ConfigureAwait(false);
+    }
+}

--- a/StreamActions.Twitch/Api/Extensions/ExtensionSecret.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionSecret.cs
@@ -1,0 +1,152 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using StreamActions.Common;
+using StreamActions.Common.Exceptions;
+using StreamActions.Common.Extensions;
+using StreamActions.Twitch.Api.Common;
+using StreamActions.Common.Logger;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Sends and represents a response element for a request for extension secrets.
+/// </summary>
+public sealed record ExtensionSecret
+{
+    /// <summary>
+    /// The version number that identifies this definition of the secret's data.
+    /// </summary>
+    [JsonPropertyName("format_version")]
+    public int? FormatVersion { get; init; }
+
+    /// <summary>
+    /// The list of secrets.
+    /// </summary>
+    [JsonPropertyName("secrets")]
+    public IReadOnlyList<ExtensionSecretData>? Secrets { get; init; }
+
+    /// <summary>
+    /// Gets an extension's list of shared secrets.
+    /// </summary>
+    /// <param name="session">The <see cref="TwitchSession"/> to authorize the request. Requires a signed JSON Web Token (JWT) created by an Extension Backend Service (EBS).</param>
+    /// <param name="extensionId">The ID of the extension whose shared secrets you want to get.</param>
+    /// <returns>A <see cref="ResponseData{TDataType}"/> with elements of type <see cref="ExtensionSecret"/> containing the response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>; <paramref name="extensionId"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="TwitchSession.Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.Jwt"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Response Codes:
+    /// <list type="table">
+    /// <item>
+    /// <term>200 OK</term>
+    /// <description>Successfully retrieved the list of secrets.</description>
+    /// </item>
+    /// <item>
+    /// <term>400 Bad Request</term>
+    /// <description>The described parameter was missing or invalid.</description>
+    /// </item>
+    /// <item>
+    /// <term>401 Unauthorized</term>
+    /// <description>The JWT token was invalid for this request due to the specified reason.</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public static async Task<ResponseData<ExtensionSecret>?> GetExtensionSecrets(TwitchSession session, string extensionId)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
+        }
+
+        session.RequireJwtToken();
+
+        if (string.IsNullOrWhiteSpace(extensionId))
+        {
+            throw new ArgumentNullException(nameof(extensionId)).Log(TwitchApi.GetLogger());
+        }
+
+        NameValueCollection queryParams = new()
+        {
+            { "extension_id", extensionId }
+        };
+
+        Uri uri = Util.BuildUri(new("/extensions/jwt/secrets"), queryParams);
+        HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Get, uri, session).ConfigureAwait(false);
+        return await response.ReadFromJsonAsync<ResponseData<ExtensionSecret>>(TwitchApi.SerializerOptions).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Creates a shared secret used to sign and verify JWT tokens.
+    /// </summary>
+    /// <param name="session">The <see cref="TwitchSession"/> to authorize the request. Requires a signed JSON Web Token (JWT) created by an Extension Backend Service (EBS).</param>
+    /// <param name="extensionId">The ID of the extension to apply the shared secret to.</param>
+    /// <param name="delay">The amount of time, in seconds, to delay activating the secret. Minimum: 300. Default: 300.</param>
+    /// <returns>A <see cref="ResponseData{TDataType}"/> with elements of type <see cref="ExtensionSecret"/> containing the response.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="session"/> is <see langword="null"/>; <paramref name="extensionId"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="InvalidOperationException"><see cref="TwitchSession.Token"/> is <see langword="null"/>; <see cref="TwitchToken.OAuth"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="TokenTypeException"><see cref="TwitchToken.Type"/> is not <see cref="TwitchToken.TokenType.Jwt"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Response Codes:
+    /// <list type="table">
+    /// <item>
+    /// <term>200 OK</term>
+    /// <description>Successfully created the new secret.</description>
+    /// </item>
+    /// <item>
+    /// <term>400 Bad Request</term>
+    /// <description>The described parameter was missing or invalid.</description>
+    /// </item>
+    /// <item>
+    /// <term>401 Unauthorized</term>
+    /// <description>The JWT token was invalid for this request due to the specified reason.</description>
+    /// </item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public static async Task<ResponseData<ExtensionSecret>?> CreateExtensionSecret(TwitchSession session, string extensionId, int delay = 300)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session)).Log(TwitchApi.GetLogger());
+        }
+
+        session.RequireJwtToken();
+
+        if (string.IsNullOrWhiteSpace(extensionId))
+        {
+            throw new ArgumentNullException(nameof(extensionId)).Log(TwitchApi.GetLogger());
+        }
+
+        NameValueCollection queryParams = new()
+        {
+            { "extension_id", extensionId },
+            { "delay", delay.ToString(CultureInfo.InvariantCulture) }
+        };
+
+        Uri uri = Util.BuildUri(new("/extensions/jwt/secrets"), queryParams);
+        HttpResponseMessage response = await TwitchApi.PerformHttpRequest(HttpMethod.Post, uri, session).ConfigureAwait(false);
+        return await response.ReadFromJsonAsync<ResponseData<ExtensionSecret>>(TwitchApi.SerializerOptions).ConfigureAwait(false);
+    }
+}

--- a/StreamActions.Twitch/Api/Extensions/ExtensionSecretData.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionSecretData.cs
@@ -16,37 +16,30 @@
  * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-using StreamActions.Common.Json.Serialization;
 using System.Text.Json.Serialization;
 
-namespace StreamActions.Twitch.Api.Bits;
+namespace StreamActions.Twitch.Api.Extensions;
 
 /// <summary>
-/// Contains details about the digital product's cost in a <see cref="ExtensionProductData"/>.
+/// Contains extension secret data.
 /// </summary>
-public sealed record ExtensionProductCost
+public sealed record ExtensionSecretData
 {
     /// <summary>
-    /// The amount exchanged for the digital product.
+    /// The raw secret that you use with JWT encoding.
     /// </summary>
-    [JsonPropertyName("amount")]
-    public int? Amount { get; init; }
+    [JsonPropertyName("content")]
+    public string? Content { get; init; }
 
     /// <summary>
-    /// The type of currency exchanged.
+    /// The UTC date and time that you may begin using this secret to sign a JWT.
     /// </summary>
-    [JsonPropertyName("type")]
-    public ExtensionProductCostType? Type { get; init; }
+    [JsonPropertyName("active_at")]
+    public DateTime? ActiveAt { get; init; }
 
     /// <summary>
-    /// The type of currency exchanged.
+    /// The UTC date and time that you must stop using this secret to decode a JWT.
     /// </summary>
-    [JsonConverter(typeof(JsonLowerCaseEnumConverter<ExtensionProductCostType>))]
-    public enum ExtensionProductCostType
-    {
-        /// <summary>
-        /// Purchase via bits.
-        /// </summary>
-        Bits
-    }
+    [JsonPropertyName("expires_at")]
+    public DateTime? ExpiresAt { get; init; }
 }

--- a/StreamActions.Twitch/Api/Extensions/ExtensionTransaction.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionTransaction.cs
@@ -26,7 +26,7 @@ using System.Collections.Specialized;
 using System.Globalization;
 using System.Text.Json.Serialization;
 
-namespace StreamActions.Twitch.Api.Bits;
+namespace StreamActions.Twitch.Api.Extensions;
 
 /// <summary>
 /// Sends and represents the response for a request for extension transactions.

--- a/StreamActions.Twitch/Api/Extensions/ExtensionVideoOverlayView.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionVideoOverlayView.cs
@@ -1,0 +1,39 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Describes how the extension is rendered if the extension may be activated as a video-overlay extension.
+/// </summary>
+public sealed record ExtensionVideoOverlayView
+{
+    /// <summary>
+    /// The HTML file that is shown to viewers on the channel page when the extension is activated on the Video - Overlay slot.
+    /// </summary>
+    [JsonPropertyName("viewer_url")]
+    public string? ViewerUrl { get; init; }
+
+    /// <summary>
+    /// A Boolean value that determines whether the extension can link to non-Twitch domains.
+    /// </summary>
+    [JsonPropertyName("can_link_external_content")]
+    public bool? CanLinkExternalContent { get; init; }
+}

--- a/StreamActions.Twitch/Api/Extensions/ExtensionViews.cs
+++ b/StreamActions.Twitch/Api/Extensions/ExtensionViews.cs
@@ -1,0 +1,57 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Describes all views-related information such as how the extension is displayed on mobile devices.
+/// </summary>
+public sealed record ExtensionViews
+{
+    /// <summary>
+    /// Describes how the extension is displayed on mobile devices.
+    /// </summary>
+    [JsonPropertyName("mobile")]
+    public ExtensionMobileView? Mobile { get; init; }
+
+    /// <summary>
+    /// Describes how the extension is rendered if the extension may be activated as a panel extension.
+    /// </summary>
+    [JsonPropertyName("panel")]
+    public ExtensionPanelView? Panel { get; init; }
+
+    /// <summary>
+    /// Describes how the extension is rendered if the extension may be activated as a video-overlay extension.
+    /// </summary>
+    [JsonPropertyName("video_overlay")]
+    public ExtensionVideoOverlayView? VideoOverlay { get; init; }
+
+    /// <summary>
+    /// Describes how the extension is rendered if the extension may be activated as a video-component extension.
+    /// </summary>
+    [JsonPropertyName("component")]
+    public ExtensionComponentView? Component { get; init; }
+
+    /// <summary>
+    /// Describes the view that is shown to broadcasters while they are configuring your extension within the Extension Manager.
+    /// </summary>
+    [JsonPropertyName("config")]
+    public ExtensionConfigView? Config { get; init; }
+}

--- a/StreamActions.Twitch/Api/Extensions/SendExtensionChatMessageParameters.cs
+++ b/StreamActions.Twitch/Api/Extensions/SendExtensionChatMessageParameters.cs
@@ -1,0 +1,45 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Parameters for <see cref="ExtensionChatMessage.SendExtensionChatMessage(Common.TwitchSession, string, SendExtensionChatMessageParameters)"/>.
+/// </summary>
+public sealed record SendExtensionChatMessageParameters
+{
+    /// <summary>
+    /// The message. The message may contain a maximum of 280 characters.
+    /// </summary>
+    [JsonPropertyName("text")]
+    public string? Text { get; init; }
+
+    /// <summary>
+    /// The ID of the extension that’s sending the chat message.
+    /// </summary>
+    [JsonPropertyName("extension_id")]
+    public string? ExtensionId { get; init; }
+
+    /// <summary>
+    /// The extension’s version number.
+    /// </summary>
+    [JsonPropertyName("extension_version")]
+    public string? ExtensionVersion { get; init; }
+}

--- a/StreamActions.Twitch/Api/Extensions/SendExtensionPubSubMessageParameters.cs
+++ b/StreamActions.Twitch/Api/Extensions/SendExtensionPubSubMessageParameters.cs
@@ -1,0 +1,53 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Parameters for <see cref="ExtensionPubSubMessage.SendExtensionPubSubMessage(Common.TwitchSession, SendExtensionPubSubMessageParameters)"/>.
+/// </summary>
+public sealed record SendExtensionPubSubMessageParameters
+{
+    /// <summary>
+    /// The target of the message. Possible values are: broadcast, global, whisper-&lt;user-id&gt;.
+    /// </summary>
+    [JsonPropertyName("target")]
+    public IReadOnlyList<string>? Target { get; init; }
+
+    /// <summary>
+    /// The ID of the broadcaster to send the message to. Don’t include this field if is_global_broadcast is set to true.
+    /// </summary>
+    [JsonPropertyName("broadcaster_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? BroadcasterId { get; init; }
+
+    /// <summary>
+    /// A Boolean value that determines whether the message should be sent to all channels where your extension is active.
+    /// </summary>
+    [JsonPropertyName("is_global_broadcast")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? IsGlobalBroadcast { get; init; }
+
+    /// <summary>
+    /// The message to send. The message can be a plain-text string or a string-encoded JSON object.
+    /// </summary>
+    [JsonPropertyName("message")]
+    public string? Message { get; init; }
+}

--- a/StreamActions.Twitch/Api/Extensions/SetExtensionConfigurationSegmentParameters.cs
+++ b/StreamActions.Twitch/Api/Extensions/SetExtensionConfigurationSegmentParameters.cs
@@ -1,0 +1,57 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Parameters for <see cref="ExtensionConfigurationSegment.SetExtensionConfigurationSegment(Common.TwitchSession, SetExtensionConfigurationSegmentParameters)"/>.
+/// </summary>
+public sealed record SetExtensionConfigurationSegmentParameters
+{
+    /// <summary>
+    /// The ID of the extension to update.
+    /// </summary>
+    [JsonPropertyName("extension_id")]
+    public string? ExtensionId { get; init; }
+
+    /// <summary>
+    /// The configuration segment to update. Possible case-sensitive values are: broadcaster, developer, global.
+    /// </summary>
+    [JsonPropertyName("segment")]
+    public string? Segment { get; init; }
+
+    /// <summary>
+    /// The ID of the broadcaster that installed the extension. Include this field only if the segment is set to developer or broadcaster.
+    /// </summary>
+    [JsonPropertyName("broadcaster_id")]
+    public string? BroadcasterId { get; init; }
+
+    /// <summary>
+    /// The contents of the segment. This string may be a plain-text string or a string-encoded JSON object.
+    /// </summary>
+    [JsonPropertyName("content")]
+    public string? Content { get; init; }
+
+    /// <summary>
+    /// The version number that identifies this definition of the segment’s data. If not specified, the latest definition is updated.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public string? Version { get; init; }
+}

--- a/StreamActions.Twitch/Api/Extensions/SetExtensionRequiredConfigurationParameters.cs
+++ b/StreamActions.Twitch/Api/Extensions/SetExtensionRequiredConfigurationParameters.cs
@@ -1,0 +1,45 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Parameters for <see cref="ExtensionRequiredConfiguration.SetExtensionRequiredConfiguration(Common.TwitchSession, string, SetExtensionRequiredConfigurationParameters)"/>.
+/// </summary>
+public sealed record SetExtensionRequiredConfigurationParameters
+{
+    /// <summary>
+    /// The ID of the extension to update.
+    /// </summary>
+    [JsonPropertyName("extension_id")]
+    public string? ExtensionId { get; init; }
+
+    /// <summary>
+    /// The version of the extension to update.
+    /// </summary>
+    [JsonPropertyName("extension_version")]
+    public string? ExtensionVersion { get; init; }
+
+    /// <summary>
+    /// The required_configuration string to use with the extension.
+    /// </summary>
+    [JsonPropertyName("required_configuration")]
+    public string? RequiredConfiguration { get; init; }
+}

--- a/StreamActions.Twitch/Api/Extensions/UpdateExtensionBitsProductParameters.cs
+++ b/StreamActions.Twitch/Api/Extensions/UpdateExtensionBitsProductParameters.cs
@@ -1,0 +1,63 @@
+/*
+ * This file is part of StreamActions.
+ * Copyright © 2019-2026 StreamActions Team (streamactions.github.io)
+ *
+ * StreamActions is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * StreamActions is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with StreamActions.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Text.Json.Serialization;
+
+namespace StreamActions.Twitch.Api.Extensions;
+
+/// <summary>
+/// Parameters for <see cref="ExtensionBitsProduct.UpdateExtensionBitsProduct(Common.TwitchSession, UpdateExtensionBitsProductParameters)"/>.
+/// </summary>
+public sealed record UpdateExtensionBitsProductParameters
+{
+    /// <summary>
+    /// The product's SKU. The SKU must be unique within an extension.
+    /// </summary>
+    [JsonPropertyName("sku")]
+    public string? Sku { get; init; }
+
+    /// <summary>
+    /// An object that contains the product's cost information.
+    /// </summary>
+    [JsonPropertyName("cost")]
+    public ExtensionProductCost? Cost { get; init; }
+
+    /// <summary>
+    /// The product's name as displayed in the extension. The maximum length is 255 characters.
+    /// </summary>
+    [JsonPropertyName("display_name")]
+    public string? DisplayName { get; init; }
+
+    /// <summary>
+    /// A Boolean value that indicates whether the product is in development.
+    /// </summary>
+    [JsonPropertyName("in_development")]
+    public bool? InDevelopment { get; init; }
+
+    /// <summary>
+    /// The date and time, in RFC3339 format, when the product expires. If not set, the product does not expire.
+    /// </summary>
+    [JsonPropertyName("expiration")]
+    public DateTime? Expiration { get; init; }
+
+    /// <summary>
+    /// A Boolean value that determines whether Bits product purchase events are broadcast to all instances of the extension on a channel.
+    /// </summary>
+    [JsonPropertyName("is_broadcast")]
+    public bool? IsBroadcast { get; init; }
+}

--- a/StreamActions.Twitch/Api/TwitchApi.cs
+++ b/StreamActions.Twitch/Api/TwitchApi.cs
@@ -276,6 +276,8 @@ public sealed partial class TwitchApi : IApi
                             }
                         }
                         break;
+                    case TwitchToken.TokenType.Jwt:
+                        break;
                     case TwitchToken.TokenType.Unknown:
                     default:
                         _logger.Warning("Unknown or uninitialized Twitch token: " + Enum.GetName(session.Token.Type.GetValueOrDefault()));

--- a/test_jwt.sh
+++ b/test_jwt.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-echo "Looking for any JWT references in Twitch API classes..."
-grep -Rn -i "jwt" StreamActions.Twitch/Api/ || echo "No JWT references found"

--- a/test_jwt.sh
+++ b/test_jwt.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "Looking for any JWT references in Twitch API classes..."
+grep -Rn -i "jwt" StreamActions.Twitch/Api/ || echo "No JWT references found"


### PR DESCRIPTION
Implemented the following Twitch API endpoints under the Extensions category:
- Get Extension Configuration Segment
- Set Extension Configuration Segment
- Set Extension Required Configuration
- Send Extension PubSub Message
- Get Extension Live Channels
- Get Extension Secrets
- Create Extension Secret
- Send Extension Chat Message
- Get Extensions
- Get Released Extensions
- Get Extension Bits Products
- Update Extension Bits Product

Also added support for JWT tokens in `TwitchSession` (`RequireJwtToken()`) and `TwitchToken.TokenType`. Moved Extension Bits Products records from the `Bits` folder to the `Extensions` folder. All tests pass and warnings resolved.

---
*PR created automatically by Jules for task [10522782858762833537](https://jules.google.com/task/10522782858762833537) started by @gmt2001*